### PR TITLE
Add styles support to createElement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Automatic `styles` support to `createElement`
 
 ## [0.2.0] - 2022-10-02
 ### Added

--- a/src/lib/styles.js
+++ b/src/lib/styles.js
@@ -1,0 +1,30 @@
+/**
+ * Join truthy object values into a semicolon-delimited string.
+ *
+ * @example
+ * {% styles {
+ *     "background-color": backgroundColor,
+ *     "--custom-property": customProperty,
+ *     "--undefined-property": "green" if undefinedProperty
+ * } %}
+ * // returns "background-color: red; --custom-property: 10px"
+ * @param {Object} args
+ * @return {string}
+ */
+module.exports = ( args ) =>
+{
+	if( !args )
+	{
+		return "";
+	}
+
+	return Object.entries( args )
+		/* eslint-disable-next-line no-unused-vars */
+		.filter( ( [property, value] ) => (
+			value !== false &&
+			value !== null &&
+			value !== undefined
+		) ) // only include truthy values
+		.map( ( [property, value] ) => `${property}: ${value}` )
+		.join( "; " );
+};

--- a/src/shortcodes/README.md
+++ b/src/shortcodes/README.md
@@ -60,7 +60,9 @@ Attributes with `null` or `undefined` values are omitted:
 </article>
 ```
 
-If `attributes` contains a property `class` whose value is an array, [`classnames`](#classnames) will be used automatically to return a space-delimited string containing only truthy, non-duplicate values:
+---
+
+If `attributes` contains a `class` property whose value is an array, [`classnames`](#classnames) will be used automatically to return a space-delimited string containing only truthy, non-duplicate values:
 
 ```njk
 {% createElement "div", {
@@ -80,6 +82,8 @@ If `attributes` contains a property `class` whose value is an array, [`classname
     <p>Hello, world.</p>
 </div>
 ```
+
+---
 
 If `attributes` contains a `style` property whose value is an object, [`styles`](#styles) will be used automatically to return a semicolon-delimited string containing only truthy values:
 
@@ -103,6 +107,8 @@ If `attributes` contains a `style` property whose value is an object, [`styles`]
 </div>
 ```
 
+---
+
 Build self-closing tags by setting `selfClosing=true`:
 
 ```njk
@@ -116,6 +122,8 @@ Build self-closing tags by setting `selfClosing=true`:
 ```html
 <input type="button">
 ```
+
+---
 
 If `tagName` is undefined, `createElement` will return `innerHTML` only:
 

--- a/src/shortcodes/README.md
+++ b/src/shortcodes/README.md
@@ -48,7 +48,7 @@ Attributes with `null` or `undefined` values are omitted:
     class: "card",
     href: undefined,
     "data-example": null,
-    "aria-hidden": false,
+    "aria-hidden": false
 } %}
     <p>Hello, world.</p>
 {% endcreateElement %}
@@ -94,7 +94,7 @@ If `attributes` contains a `style` property whose value is an object, [`styles`]
         "--false-property": false,
         "--null-property": null,
         "--undefined-property": undefined,
-        "background-color": "red",
+        "background-color": "red"
     },
 } %}
     <p>Hello, world.</p>

--- a/src/shortcodes/README.md
+++ b/src/shortcodes/README.md
@@ -81,6 +81,28 @@ If `attributes` contains a property `class` whose value is an array, [`classname
 </div>
 ```
 
+If `attributes` contains a `style` property whose value is an object, [`styles`](#styles) will be used automatically to return a semicolon-delimited string containing only truthy values:
+
+```njk
+{% createElement "div", {
+    style: {
+        "--custom-property": "10px",
+        "--false-property": false,
+        "--null-property": null,
+        "--undefined-property": undefined,
+        "background-color": "red",
+    },
+} %}
+    <p>Hello, world.</p>
+{% endcreateElement %}
+```
+
+```html
+<div style="--custom-property: 10px; background-color: red"></div>
+    <p>Hello, world.</p>
+</div>
+```
+
 Build self-closing tags by setting `selfClosing=true`:
 
 ```njk

--- a/src/shortcodes/createElement.js
+++ b/src/shortcodes/createElement.js
@@ -1,4 +1,5 @@
 const classnames = require( "../lib/classnames" );
+const styles = require( "../lib/styles" );
 
 /**
  * @returns {Function}
@@ -71,12 +72,15 @@ module.exports.pairedShortcode = () =>
 				{
 					return ` ${key}="${classnames.apply( null, value )}"`;
 				}
-				else
+
+				if( key === "style" && typeof value === "object" )
 				{
-					if( value !== undefined && value !== null )
-					{
-						return ` ${key}="${value}"`;
-					}
+					return ` ${key}="${styles( value )}"`;
+				}
+
+				if( value !== undefined && value !== null )
+				{
+					return ` ${key}="${value}"`;
 				}
 			} )
 			.join( "" );

--- a/src/shortcodes/styles.js
+++ b/src/shortcodes/styles.js
@@ -1,36 +1,6 @@
+const styles = require( "../lib/styles" );
+
 /**
  * @returns {Function}
  */
-module.exports.shortcode = () =>
-{
-	/**
-	 * Join truthy object values into a semicolon-delimited string.
-	 *
-	 * @example
-	 * {% styles {
-	 *     "background-color": backgroundColor,
-	 *     "--custom-property": customProperty,
-	 *     "--undefined-property": "green" if undefinedProperty
-	 * } %}
-	 * // returns "background-color: red; --custom-property: 10px"
-	 * @param {Object} args
-	 * @return {string}
-	 */
-	return ( args ) =>
-	{
-		if( !args )
-		{
-			return "";
-		}
-
-		return Object.entries( args )
-			/* eslint-disable-next-line no-unused-vars */
-			.filter( ( [property, value] ) => (
-				value !== false &&
-				value !== null &&
-				value !== undefined
-			) ) // only include truthy values
-			.map( ( [property, value] ) => `${property}: ${value}` )
-			.join( "; " );
-	};
-};
+module.exports.shortcode = () => styles;

--- a/test/shortcodes/createElement.js
+++ b/test/shortcodes/createElement.js
@@ -98,6 +98,26 @@ describe( "createElement (paired shortcode)", () =>
 				"<div class=\"block block__element block__element--modifier\"></div>",
 			);
 		} );
+
+		it( "should use `styles` if `style` attribute value is an Object", () =>
+		{
+			assert.equal(
+				createElement(
+					undefined,
+					"div",
+					{
+						style: {
+							"--custom-property": "10px",
+							"--false-property": false,
+							"--null-property": null,
+							"--undefined-property": undefined,
+							"background-color": "red",
+						},
+					},
+				),
+				"<div style=\"--custom-property: 10px; background-color: red\"></div>",
+			);
+		} );
 	} );
 
 	describe( "#selfClosing", () =>

--- a/test/shortcodes/createElement.js
+++ b/test/shortcodes/createElement.js
@@ -4,120 +4,132 @@ const { assert } = require( "chai" );
 
 describe( "createElement (paired shortcode)", () =>
 {
-	it( "should return an HTML element using the tagName provided", () =>
+	describe( "#innerHTML", () =>
 	{
-		assert.equal( createElement( undefined, "a" ), "<a></a>" );
+		it( "should return an HTML element using the innerHTML provided", () =>
+		{
+			assert.equal(
+				createElement(
+					"<h1>Hello, world</h1>",
+					"article",
+					{
+						class: "post post--new",
+						"data-example": "Lorem ipsum",
+					},
+				),
+				"<article class=\"post post--new\" data-example=\"Lorem ipsum\"><h1>Hello, world</h1></article>",
+			);
+		} );
 	} );
 
-	it( "should return an HTML element using the attributes provided", () =>
+	describe( "#tagName", () =>
 	{
-		assert.equal(
-			createElement(
-				undefined,
-				"article",
-				{
-					class: "post post--new",
-					"data-example": "Lorem ipsum",
-				},
-			),
-			"<article class=\"post post--new\" data-example=\"Lorem ipsum\"></article>",
-		);
-	} );
+		it( "should return an HTML element using the tagName provided", () =>
+		{
+			assert.equal( createElement( undefined, "a" ), "<a></a>" );
+		} );
 
-	it( "should omit attributes whose values are undefined or null", () =>
-	{
-		assert.equal(
-			createElement(
-				undefined,
-				"article",
-				{
-					class: "card",
-					href: undefined,
-					"data-example": null,
-					"aria-hidden": false,
-				},
-			),
-			"<article class=\"card\" aria-hidden=\"false\"></article>",
-		);
-	} );
-
-	it( "should return a self-closing HTML element if specified", () =>
-	{
-		assert.equal(
-			createElement(
-				undefined,
-				"source",
-				{
-					width: 500,
-				},
-				true,
-			),
-			"<source width=\"500\">",
-		);
-	} );
-
-	it( "should ignore innerHTML if self-closing HTML element is specified", () =>
-	{
-		assert.equal(
-			createElement(
+		it( "should return innerHTML only if tagName is falsy", () =>
+		{
+			assert.equal(
+				createElement(
+					"hello, world",
+					undefined,
+					{
+						width: 500,
+					},
+					true,
+				),
 				"hello, world",
-				"source",
-				{
-					width: 500,
-				},
-				true,
-			),
-			"<source width=\"500\">",
-		);
+			);
+		} );
 	} );
 
-	it( "should return innerHTML only if tagName is falsy", () =>
+	describe( "#attributes", () =>
 	{
-		assert.equal(
-			createElement(
-				"hello, world",
-				undefined,
-				{
-					width: 500,
-				},
-				true,
-			),
-			"hello, world",
-		);
+		it( "should return an HTML element using the attributes provided", () =>
+		{
+			assert.equal(
+				createElement(
+					undefined,
+					"article",
+					{
+						class: "post post--new",
+						"data-example": "Lorem ipsum",
+					},
+				),
+				"<article class=\"post post--new\" data-example=\"Lorem ipsum\"></article>",
+			);
+		} );
+
+		it( "should omit attributes whose values are undefined or null", () =>
+		{
+			assert.equal(
+				createElement(
+					undefined,
+					"article",
+					{
+						class: "card",
+						href: undefined,
+						"data-example": null,
+						"aria-hidden": false,
+					},
+				),
+				"<article class=\"card\" aria-hidden=\"false\"></article>",
+			);
+		} );
+
+		it( "should use `classnames` if `class` attribute value is an array", () =>
+		{
+			assert.equal(
+				createElement(
+					undefined,
+					"div",
+					{
+						class: [
+							"block",
+							undefined,
+							"block__element",
+							false,
+							"block__element--modifier",
+						],
+					},
+				),
+				"<div class=\"block block__element block__element--modifier\"></div>",
+			);
+		} );
 	} );
 
-	it( "should return an HTML element using the innerHTML provided", () =>
+	describe( "#selfClosing", () =>
 	{
-		assert.equal(
-			createElement(
-				"<h1>Hello, world</h1>",
-				"article",
-				{
-					class: "post post--new",
-					"data-example": "Lorem ipsum",
-				},
-			),
-			"<article class=\"post post--new\" data-example=\"Lorem ipsum\"><h1>Hello, world</h1></article>",
-		);
-	} );
+		it( "should return a self-closing HTML element if specified", () =>
+		{
+			assert.equal(
+				createElement(
+					undefined,
+					"source",
+					{
+						width: 500,
+					},
+					true,
+				),
+				"<source width=\"500\">",
+			);
+		} );
 
-	it( "should use `classnames` if `class` attribute value is an array", () =>
-	{
-		assert.equal(
-			createElement(
-				undefined,
-				"div",
-				{
-					class: [
-						"block",
-						undefined,
-						"block__element",
-						false,
-						"block__element--modifier",
-					],
-				},
-			),
-			"<div class=\"block block__element block__element--modifier\"></div>",
-		);
+		it( "should ignore innerHTML if self-closing HTML element is specified", () =>
+		{
+			assert.equal(
+				createElement(
+					"hello, world",
+					"source",
+					{
+						width: 500,
+					},
+					true,
+				),
+				"<source width=\"500\">",
+			);
+		} );
 	} );
 } );


### PR DESCRIPTION
## Summary

Updates the `createElement` shortcode to automatically use [`styles`](https://github.com/ashur/eleventy-toolkit/blob/create-element-styles/src/lib/styles.js) if the `style` attribute is an Object:

```njk
{% createElement "div", {
    style: {
        "--custom-property": "10px",
        "--false-property": false,
        "--null-property": null,
        "--undefined-property": undefined,
        "background-color": "red"
    },
} %}
    <p>Hello, world.</p>
{% endcreateElement %}
```

```html
<div style="--custom-property: 10px; background-color: red"></div>
    <p>Hello, world.</p>
</div>
```