### PR TITLE
Add automatic self-closing tag support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Automatic `styles` support to `createElement`
 
+### Changed
+- `createElement` creates self-closing tags for empty elements automatically instead of relying on the `selfClosing` parameter
+
 ## [0.2.0] - 2022-10-02
 ### Added
 - `createElement` paired shortcode

--- a/src/shortcodes/README.md
+++ b/src/shortcodes/README.md
@@ -41,8 +41,8 @@ Build HTML elements, with support for dynamic tag names and attributes.
 ### Usage
 
 ```njk
-{% createElement <tagName>, [<attributes>, [<selfClosing>]] %}
-    <!-- <innerHTML> -->
+{% createElement <name>, [<attributes>] %}
+    <innerHTML>
 {% endcreateElement %}
 ```
 
@@ -114,13 +114,11 @@ If `attributes` contains a `style` property whose value is an object, [`styles`]
 
 ---
 
-Build self-closing tags by setting `selfClosing=true`:
+[Empty elements](https://developer.mozilla.org/en-US/docs/Glossary/empty_element) will build self-closing tags automatically:
 
 ```njk
-{% createElement "input", {
-    type: "button"
-}, true %}
-    <p>innerHTML is ignored when building self-closing tags</p>
+{% createElement "input", { type: "button" } %}
+    <p>innerHTML is ignored when building empty elements</p>
 {% endcreateElement %}
 ```
 
@@ -130,7 +128,7 @@ Build self-closing tags by setting `selfClosing=true`:
 
 ---
 
-If `tagName` is undefined, `createElement` will return `innerHTML` only:
+If `name` is undefined, `createElement` will return `innerHTML` only:
 
 ```njk
 {% createElement "a" if link, { href: link } -%}

--- a/src/shortcodes/createElement.js
+++ b/src/shortcodes/createElement.js
@@ -2,6 +2,29 @@ const classnames = require( "../lib/classnames" );
 const styles = require( "../lib/styles" );
 
 /**
+ * @see https://developer.mozilla.org/en-US/docs/Glossary/empty_element
+ */
+const emptyElements = [
+	"area",
+	"base",
+	"br",
+	"col",
+	"embed",
+	"hr",
+	"img",
+	"input",
+	"keygen",
+	"link",
+	"meta",
+	"param",
+	"source",
+	"track",
+	"wbr",
+];
+
+module.exports.emptyElements = emptyElements;
+
+/**
  * @returns {Function}
  */
 module.exports.pairedShortcode = () =>
@@ -53,14 +76,13 @@ module.exports.pairedShortcode = () =>
 	 * // returns `<input type="button">`
 	 *
 	 * @param {string} innerHTML
-	 * @param {string} tagName
+	 * @param {string} name - name of the HTML element
 	 * @param {Object} [attributes]
-	 * @param {boolean} [selfClosing=false]
 	 * @return {string}
 	 */
-	return ( innerHTML, tagName, attributes = {}, selfClosing=false ) =>
+	return ( innerHTML, name, attributes = {} ) =>
 	{
-		if( !tagName )
+		if( !name )
 		{
 			return innerHTML;
 		}
@@ -85,9 +107,11 @@ module.exports.pairedShortcode = () =>
 			} )
 			.join( "" );
 
-		const openingTag = `<${tagName}${attributesString}${ selfClosing ? "" : ">" }`;
-		const tagContent = selfClosing ? "" : innerHTML || "";
-		const closingTag = selfClosing ? ">" : `</${tagName}>`;
+		const isEmpty = emptyElements.includes( name );
+
+		const openingTag = `<${name}${attributesString}${ isEmpty ? "" : ">" }`;
+		const tagContent = isEmpty ? "" : innerHTML || "";
+		const closingTag = isEmpty ? ">" : `</${name}>`;
 
 		return `${ openingTag }${ tagContent }${ closingTag }`;
 	};

--- a/test/shortcodes/createElement.js
+++ b/test/shortcodes/createElement.js
@@ -22,6 +22,20 @@ describe( "createElement (paired shortcode)", () =>
 				"<article class=\"post post--new\" data-example=\"Lorem ipsum\"><h1>Hello, world</h1></article>",
 			);
 		} );
+
+		it( "should ignore innerHTML when rendering empty elements", () =>
+		{
+			assert.equal(
+				createElement(
+					"<p>Hello, world</p>",
+					"img",
+					{
+						src: "https://example.com/example.jpg",
+					},
+				),
+				"<img src=\"https://example.com/example.jpg\">",
+			);
+		} );
 	} );
 
 	describe( "#name", () =>

--- a/test/shortcodes/createElement.js
+++ b/test/shortcodes/createElement.js
@@ -1,6 +1,8 @@
 /* global describe, it */
-const createElement = require( "../../src/shortcodes/createElement" ).pairedShortcode();
 const { assert } = require( "chai" );
+const { emptyElements, pairedShortcode } = require( "../../src/shortcodes/createElement" );
+
+const createElement = pairedShortcode();
 
 describe( "createElement (paired shortcode)", () =>
 {
@@ -22,14 +24,14 @@ describe( "createElement (paired shortcode)", () =>
 		} );
 	} );
 
-	describe( "#tagName", () =>
+	describe( "#name", () =>
 	{
-		it( "should return an HTML element using the tagName provided", () =>
+		it( "should return an HTML element using the name provided", () =>
 		{
 			assert.equal( createElement( undefined, "a" ), "<a></a>" );
 		} );
 
-		it( "should return innerHTML only if tagName is falsy", () =>
+		it( "should return only innerHTML if name is falsy", () =>
 		{
 			assert.equal(
 				createElement(
@@ -42,6 +44,17 @@ describe( "createElement (paired shortcode)", () =>
 				),
 				"hello, world",
 			);
+		} );
+
+		it( "should return self-closing tag if name is an empty element", () =>
+		{
+			emptyElements.forEach( ( name ) =>
+			{
+				assert.equal(
+					createElement( undefined, name ),
+					`<${name}>`,
+				);
+			} );
 		} );
 	} );
 
@@ -116,39 +129,6 @@ describe( "createElement (paired shortcode)", () =>
 					},
 				),
 				"<div style=\"--custom-property: 10px; background-color: red\"></div>",
-			);
-		} );
-	} );
-
-	describe( "#selfClosing", () =>
-	{
-		it( "should return a self-closing HTML element if specified", () =>
-		{
-			assert.equal(
-				createElement(
-					undefined,
-					"source",
-					{
-						width: 500,
-					},
-					true,
-				),
-				"<source width=\"500\">",
-			);
-		} );
-
-		it( "should ignore innerHTML if self-closing HTML element is specified", () =>
-		{
-			assert.equal(
-				createElement(
-					"hello, world",
-					"source",
-					{
-						width: 500,
-					},
-					true,
-				),
-				"<source width=\"500\">",
 			);
 		} );
 	} );


### PR DESCRIPTION
## Summary

- Updates `createElement` to automatically render self-closing tags for all empty elements
- Removes `createElement`'s `selfClosing` parameter, which is no longer needed